### PR TITLE
PLATFORM-8969 | Use RIGOR_SECURE for permission checks outside submit

### DIFF
--- a/includes/PF_FormPrinter.php
+++ b/includes/PF_FormPrinter.php
@@ -14,6 +14,7 @@
  */
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Permissions\PermissionManager;
 
 class PFFormPrinter {
 
@@ -905,8 +906,9 @@ END;
 		// permission errors from the start, and use those to determine
 		// whether the page is editable.
 		if ( !$is_query ) {
+			$rigor = $form_submitted ? PermissionManager::RIGOR_SECURE : PermissionManager::RIGOR_FULL;
 			$permissionErrors = MediaWikiServices::getInstance()->getPermissionManager()
-				->getPermissionErrors( 'edit', $user, $this->mPageTitle );
+				->getPermissionErrors( 'edit', $user, $this->mPageTitle, $rigor );
 			if ( MediaWikiServices::getInstance()->getReadOnlyMode()->isReadOnly() ) {
 				$permissionErrors = [ [ 'readonlytext', [ MediaWikiServices::getInstance()->getReadOnlyMode()->getReason() ] ] ];
 			}


### PR DESCRIPTION
This avoids TransactionProfiler warnings when rendering action=formedit.

Change-Id: I611efe0ba1d269fbf7a5f0d51bd595b12f0c8f1d